### PR TITLE
Add fullHeight option to obc-button

### DIFF
--- a/packages/openbridge-webcomponents/src/components/button/button.css
+++ b/packages/openbridge-webcomponents/src/components/button/button.css
@@ -18,6 +18,14 @@
     }
   }
 
+  &.full-height {
+    height: 100%;
+
+    & .visible-wrapper {
+      height: 100%;
+    }
+  }
+
   & .visible-wrapper {
     border-radius: 6px;
     display: flex;

--- a/packages/openbridge-webcomponents/src/components/button/button.ts
+++ b/packages/openbridge-webcomponents/src/components/button/button.ts
@@ -16,6 +16,7 @@ export class ObcButton extends LitElement {
   @property({type: String}) variant = 'normal';
   @property({type: String}) size = 'regular';
   @property({type: Boolean}) fullWidth = false;
+  @property({type: Boolean}) fullHeight = false;
   @property({type: Boolean}) hugText = false;
   @property({type: Boolean}) checked = false;
   @property({type: Boolean}) disabled = false;
@@ -45,6 +46,7 @@ export class ObcButton extends LitElement {
           hasIconLeading: this.hasIconLeading,
           hasIconTrailing: this.hasIconTrailing,
           'full-width': this.fullWidth,
+          'full-height': this.fullHeight,
           'hug-text': this.hugText,
           checked: this.checked,
         })}
@@ -52,7 +54,7 @@ export class ObcButton extends LitElement {
         href=${ifDefined(this.href)}
         target=${ifDefined(this.target)}
       >
-        <div class="visible-wrapper">
+        <div class="visible-wrapper ${classMap({'full-height': this.fullHeight})}">
           <span class="icon leading"><slot name="leading-icon"></slot></span>
           <span class="label"><slot></slot></span>
           <span class="icon trailing"><slot name="trailing-icon"></slot></span>


### PR DESCRIPTION
In one of our projects we need the obc-button to be full-height.
This PR adds fullHeight functionality similar to the existing fullWidth option.

![full-height](https://github.com/user-attachments/assets/e31cd73b-b483-4875-8789-f94f51881db9)
