### PR TITLE
Possibility to define custom content for top bar.

### DIFF
--- a/packages/openbridge-webcomponents/src/components/top-bar/top-bar.stories.ts
+++ b/packages/openbridge-webcomponents/src/components/top-bar/top-bar.stories.ts
@@ -135,3 +135,21 @@ export const Reponsive: Story = {
     alertBreakpoint: 700,
   },
 };
+
+export const CustomBar: Story = {
+  render: () =>
+      html`<obc-top-bar
+      ?showappsbutton=${false}
+      ?showdimmingbutton=${false}
+      ?showclock=${true}
+      appTitle=""
+      pageName=""
+    >
+      <obc-navigation-item slot="bar" label="Generator" href="#">
+        <obi-generator slot="icon"></obi-generator>
+      </obc-navigation-item>
+      <obc-navigation-item slot="bar" label="Azimuth" href="#">
+        <obi-propulsion-azimuth-thruster slot="icon"></obi-propulsion-azimuth-thruster>
+      </obc-navigation-item>
+    </obc-top-bar>`,
+};

--- a/packages/openbridge-webcomponents/src/components/top-bar/top-bar.ts
+++ b/packages/openbridge-webcomponents/src/components/top-bar/top-bar.ts
@@ -123,8 +123,12 @@ export class ObcTopBar extends LitElement {
           </div>`
         );
       }
-      leftGroup.push(html`<div class="title">${this.appTitle}</div>`);
-      leftGroup.push(html`<div class="page-name">${this.pageName}</div>`);
+      if (this.appTitle) {
+        leftGroup.push(html`<div class="title">${this.appTitle}</div>`);
+      }
+      if (this.pageName) {
+        leftGroup.push(html`<div class="page-name">${this.pageName}</div>`);
+      }
     }
 
     const breakpointMoreButton = Math.max(
@@ -170,7 +174,10 @@ export class ObcTopBar extends LitElement {
           settings: this.settings,
         })}
       >
-        <div class="left group">${leftGroup}</div>
+        <div class="left group">
+          ${leftGroup}
+          <slot name="bar"></slot>
+        </div>
         <div class="right group">
           ${this.showClock
             ? html`<obc-clock


### PR DESCRIPTION
Application top currently only supports very particular set of items on the left side - either breadcrumb (only for settings variant) or app title + page name. I think it may be more common for apps to make use of this bar - eg we want to use it for navigation quick links. This PR adds new slot to top bar component allowing more customization.